### PR TITLE
fix typo - alert-details component

### DIFF
--- a/frontend/src/app/alerts/components/alert-details/alert-details.component.html
+++ b/frontend/src/app/alerts/components/alert-details/alert-details.component.html
@@ -144,7 +144,7 @@
                                 <query-editor-proto [label]="'Q' + (index + 1)" [query]="query" [queries]="queries"
                                     [widget]="{queries: queries}"
                                     [options]="{
-                                        enableNamesapce: enableNamespace,
+                                        enableNamespace: enableNamespace,
                                         metaSource: data.type === 'healthcheck' ? 'aurastatus:check' : 'meta',
                                         enableMultipleQueries: data.type === 'simple',
                                         enableMetric: data.type === 'simple',


### PR DESCRIPTION
Due to a typo in https://github.com/OpenTSDB/opentsdb-horizon/commit/aad3d3a501f350c1ce28fd040431f15c1927fbe4, the namespace toggle is not displayed again in the alert edit screen.

Related links:
- https://github.com/OpenTSDB/opentsdb-horizon/pull/1
- https://github.com/OpenTSDB/opentsdb-horizon/commit/aad3d3a501f350c1ce28fd040431f15c1927fbe4